### PR TITLE
feat: whitelist additional vica domains

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -99,5 +99,6 @@
         https://vica.gov.sg
         https://s3-va-prd-vica.s3-ap-southeast-1.amazonaws.com
         wss://chat.vica.gov.sg
+        https://api-vica-ana.vica.gov.sg/api/v1/response-ratings
         ;
       """

--- a/netlify.toml
+++ b/netlify.toml
@@ -39,6 +39,8 @@
         https://*.licdn.com 
         https://webchat.vica.gov.sg 
         https://vica.gov.sg
+        https://www.google.com/recaptcha/
+        https://www.gstatic.com/recaptcha/
         ; 
       object-src 
         'self'
@@ -72,6 +74,8 @@
         https://www.checkfirst.gov.sg 
         https://docs.google.com 
         https://nlb.ap.panopto.com
+        https://www.google.com/recaptcha/
+        https://www.gstatic.com/recaptcha/
         ; 
       frame-ancestors 
         'none'

--- a/overrides/netlify.toml
+++ b/overrides/netlify.toml
@@ -99,5 +99,6 @@
         https://vica.gov.sg
         https://s3-va-prd-vica.s3-ap-southeast-1.amazonaws.com
         wss://chat.vica.gov.sg
+        https://api-vica-ana.vica.gov.sg/api/v1/response-ratings
         ;
       """

--- a/overrides/netlify.toml
+++ b/overrides/netlify.toml
@@ -39,6 +39,8 @@
         https://*.licdn.com 
         https://webchat.vica.gov.sg 
         https://vica.gov.sg
+        https://www.google.com/recaptcha/
+        https://www.gstatic.com/recaptcha/
         ; 
       object-src 
         'self'
@@ -72,6 +74,8 @@
         https://www.checkfirst.gov.sg 
         https://docs.google.com 
         https://nlb.ap.panopto.com
+        https://www.google.com/recaptcha/
+        https://www.gstatic.com/recaptcha/
         ; 
       frame-ancestors 
         'none'


### PR DESCRIPTION
This PR modifies the CSP by adding `https://api-vica-ana.vica.gov.sg/api/v1/response-ratings` and urls associated with the Google reCAPTCHA service (see [documentation](https://developers.google.com/recaptcha/docs/faq)).

Note that the docs specify that the nonce-based approach is recommended, however since we run static websites we don't have a way of updating the CSP dynamically. Thus, we are using the alternative specified way of whitelisting for `script-src` and `frame-src`:
- https://www.google.com/recaptcha/
- https://www.gstatic.com/recaptcha/
