### PR TITLE
fix: adds check for next-gen template before running isomer-build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,13 @@
 #!/bin/bash 
 
+################################################
+# Check repo is running on isomer v2 template. #
+################################################
+if ! grep -Fxq "remote_theme: isomerpages/isomerpages-template@next-gen" /opt/build/repo/_config.yml; then
+  echo "$1 is not on isomerpages/isomerpages-template@next-gen"
+  exit 1
+fi
+
 #################################################################
 # Override netlify.toml with centrally-hosted netlify.toml file #
 #################################################################


### PR DESCRIPTION
This PR adds a check whether the template of the repo has the configuration settings `remote_theme: isomerpages/isomerpages-template@next-gen` before proceeding with the build process. 

Currently, if an v1 Isomer site with `remote_theme: isomerpages/isomerpages-template` builds via `isomer-build`, the build process will complete successfully but all page layouts will be broken, seen here:
https://app.netlify.com/sites/isomer-dlp-prod/deploys/611e522ba6a44f28a2ed826a
https://611e522ba6a44f28a2ed826a--isomer-dlp-prod.netlify.app

This PR adds a check to throw an error and exit the build process if we attempt to build a v1 site via `isomer-build`.