### PR TITLE
Add datagov to netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -76,6 +76,7 @@
         https://nlb.ap.panopto.com
         https://www.google.com/recaptcha/
         https://www.gstatic.com/recaptcha/
+        https://data.gov.sg
         ; 
       frame-ancestors 
         'none'


### PR DESCRIPTION
This PR modifies the CSP by adding `data.gov.sg` to the list of whitelisted sites.