### PR TITLE
feat(zendesk): add entries to CSP

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -41,6 +41,12 @@
         https://vica.gov.sg
         https://www.google.com/recaptcha/
         https://www.gstatic.com/recaptcha/
+        https://static.zdassets.com
+        https://ekr.zdassets.com
+        https://*.zendesk.com
+        https://*.zopim.com
+        wss://*.zendesk.com
+        wss://*.zopim.com
         ; 
       object-src 
         'self'
@@ -105,5 +111,11 @@
         https://s3-va-prd-vica.s3-ap-southeast-1.amazonaws.com
         wss://chat.vica.gov.sg
         https://api-vica-ana.vica.gov.sg/api/v1/response-ratings
+        https://static.zdassets.com
+        https://ekr.zdassets.com
+        https://*.zendesk.com
+        https://*.zopim.com
+        wss://*.zendesk.com
+        wss://*.zopim.com
         ;
       """


### PR DESCRIPTION
## Problem and Solution

Take reference from the SDK docs[^1] and add entries to allow Zendesk Chat to 
operate out of Isomer sites.

Of concern would be the wildcarding of zendesk.com subdomains.
This would allow anybody to chat to users from any Zendesk instance.
Given the relative difficulty to acquire maintain Zendesk, this should
not present too much of a risk.

[^1]: https://developer.zendesk.com/documentation/classic-web-widget-sdks/web-widget/integrating-with-google/csp/#custom-setup-using-other-csp-directives
