### PR TITLE
Fix/disable object-src

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -49,7 +49,7 @@
         wss://*.zopim.com
         ; 
       object-src 
-        'self'
+        'none'
         ; 
       style-src 
         'self' 

--- a/overrides/netlify.toml
+++ b/overrides/netlify.toml
@@ -49,7 +49,7 @@
         wss://*.zopim.com
         ; 
       object-src 
-        'self'
+        'none'
         ; 
       style-src 
         'self' 


### PR DESCRIPTION
This PR changes the `object-src` setting in our CSP to `none`. Elements controlled by object-src are considered legacy HTML elements and aren't receiving new standardised features, which is a potential vulnerability, hence the recommendation is to set this directive to `none`.