### PR TITLE
Fix: change build command

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -54,4 +54,4 @@ while getopts "e:" opt; do
 done
 
 # netlify build
-JEKYLL_ENV=$env git lfs install && jekyll build --config _config.yml",$var",/opt/build/repo/_config-override.yml
+JEKYLL_ENV=$env jekyll build --config _config.yml",$var",/opt/build/repo/_config-override.yml


### PR DESCRIPTION
## Problem

This PR fixes an issue where staging sites were not properly displaying the staging masthead. We originally introduced the installation of `git lfs` in https://github.com/opengovsg/isomer-build/pull/19 - however, the solution introduced in that PR introduced a bug in that the `staging` flag was not being correctly passed to the jekyll environment. As we now utilise environment variables on netlify directly to use git-lfs, we can now remove the installation inside the build script as well, which should fix the staging masthead.
