### PR TITLE
feat: allow google cal, instagram and facebook

### DIFF
--- a/overrides/netlify.toml
+++ b/overrides/netlify.toml
@@ -48,6 +48,7 @@
         https://ekr.zdassets.com
         https://*.zendesk.com
         https://*.zopim.com
+        https://www.instagram.com
         wss://*.zendesk.com
         wss://*.zopim.com
         ; 

--- a/overrides/netlify.toml
+++ b/overrides/netlify.toml
@@ -90,6 +90,7 @@
         https://data.gov.sg
         https://calendar.google.com
         https://www.facebook.com
+        https://m.facebook.com/
         https://www.instagram.com
         ; 
       frame-ancestors 

--- a/overrides/netlify.toml
+++ b/overrides/netlify.toml
@@ -87,6 +87,7 @@
         https://www.google.com/recaptcha/
         https://www.gstatic.com/recaptcha/
         https://data.gov.sg
+        https://calendar.google.com
         ; 
       frame-ancestors 
         'none'

--- a/overrides/netlify.toml
+++ b/overrides/netlify.toml
@@ -90,6 +90,7 @@
         https://data.gov.sg
         https://calendar.google.com
         https://www.facebook.com
+        https://www.instagram.com
         ; 
       frame-ancestors 
         'none'

--- a/overrides/netlify.toml
+++ b/overrides/netlify.toml
@@ -88,6 +88,7 @@
         https://www.gstatic.com/recaptcha/
         https://data.gov.sg
         https://calendar.google.com
+        https://www.facebook.com
         ; 
       frame-ancestors 
         'none'


### PR DESCRIPTION
This PR allows Isomer users to embed Google Calendar, Instagram, and Facebook elements onto Isomer sites.

Specifically, it allows:
- frame-src for `https://calendar.google.com`, `https://www.facebook.com`, `https://www.instagram.com`
- script-src for `https://www.instagram.com`


#### Testing

We set up a [test page](https://staging--a-test-v4-staging.netlify.app/title-4) with the proposed CSP changes and verified that we could embed the 3 elements.
![Screenshot 2022-05-23 at 10 23 33 AM](https://user-images.githubusercontent.com/19917616/169731635-5d8b4479-640a-4fa0-9796-bcf6ef273050.png)

