### PR TITLE
feat(build.sh): enable trace during builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -54,4 +54,4 @@ while getopts "e:" opt; do
 done
 
 # netlify build
-JEKYLL_ENV=$env jekyll build --config _config.yml",$var",/opt/build/repo/_config-override.yml
+JEKYLL_ENV=$env jekyll build --trace --config _config.yml",$var",/opt/build/repo/_config-override.yml


### PR DESCRIPTION
## Problem

currently builds in amplify does not have any trace.

## Solution

add `trace` flag 
