### PR TITLE
feat(sass): compress SASS styles

### DIFF
--- a/overrides/_config-override.yml
+++ b/overrides/_config-override.yml
@@ -9,3 +9,5 @@ plugins:
 # Approved remote_theme
 remote_theme: isomerpages/isomerpages-template@next-gen
 safe: false
+sass:
+  style: compressed


### PR DESCRIPTION
## Problem

_What problem are you trying to solve? What issue does this close?_

Part of https://github.com/isomerpages/isomerpages-template/pull/307, the SCSS styles by default are not compressed.

## Solution

_How did you solve the problem?_

**Features**:

- SCSS files are now compressed

## Tests

_What tests should be run to confirm functionality?_

The `template-test` site is using `amplify-next-gen-staging`, which sets this new configuration.

## Deploy Notes

_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc._

*None*