### PR TITLE
fix(algolia): allow for batching to work

### DIFF
--- a/overrides/customHttp.yml
+++ b/overrides/customHttp.yml
@@ -151,6 +151,5 @@ customHeaders:
           https://*.dcube.cloud/
           https://console-flex-api.ap.sabio.cloud
           https://authmiddleware.ap.sabio.cloud
-          https://1v7dzgzjkk-1.algolianet.com/
           https://1v7dzgzjkk-*.algolianet.com/
           ;

--- a/overrides/customHttp.yml
+++ b/overrides/customHttp.yml
@@ -152,6 +152,5 @@ customHeaders:
           https://console-flex-api.ap.sabio.cloud
           https://authmiddleware.ap.sabio.cloud
           https://1v7dzgzjkk-1.algolianet.com/
-          https://1v7dzgzjkk.algolianet.com/
           https://1v7dzgzjkk-*.algolianet.com/
           ;

--- a/overrides/customHttp.yml
+++ b/overrides/customHttp.yml
@@ -152,4 +152,6 @@ customHeaders:
           https://console-flex-api.ap.sabio.cloud
           https://authmiddleware.ap.sabio.cloud
           https://1v7dzgzjkk-1.algolianet.com/
+          https://1v7dzgzjkk.algolianet.com/
+          https://1v7dzgzjkk-*.algolianet.com/
           ;


### PR DESCRIPTION
We were seeing intermittent errors in the instasearch library. Specifically `algoliasearch-lite.umd.js` was calling a url that we did not expect. It seems from the screenshots below that algoliasearch does some sort of batching, and sometimes it calls a different url that we did not whitelist in our csp. 

Calling `https://1v7dzgzjkk-dsn.algolia.net/1/indexes/*/`
![Screenshot 2024-04-23 at 11 01 30 AM](https://github.com/opengovsg/isomer-build/assets/42832651/7c0d3bb9-85ff-4bc1-8de1-a48408db6e29)

Calling `https://1v7dzgzjkk-2.algolia.net/1/indexes/*/` 
![Screenshot 2024-04-23 at 10 57 37 AM](https://github.com/opengovsg/isomer-build/assets/42832651/aadd074c-a4f5-45f5-8cd4-d50ace9c8839)

Calling `https://1v7dzgzjkk-3.algolia.net/1/indexes/*/`
![Screenshot 2024-04-23 at 10 47 09 AM](https://github.com/opengovsg/isomer-build/assets/42832651/f21195d1-7fe8-4bcb-9dc8-739b3db7b40e)

To allow for the batching, we instead whitelist `https://1v7dzgzjkk-*.algolia.net/` instead!
 
